### PR TITLE
Show node role like kubectl get node

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Arena is a command-line interface to run and monitor the machine learning traini
 - [3. Run a distributed training Job](docs/userguide/3-tfjob-distributed.md)
 - [4. Run a distributed training Job with external data](docs/userguide/4-tfjob-distributed-data.md)
 - [5. Run a distributed training Job based on MPI](docs/userguide/5-mpijob-distributed.md)
-- [6. Run a distributed TensorFlow training job with gang scheduler](docs/userguide/5-mpijob-distributed.md)
+- [6. Run a distributed TensorFlow training job with gang scheduler](docs/userguide/6-tfjob-gangschd.md)
 
 ## Demo
 

--- a/cmd/arena/commands/const.go
+++ b/cmd/arena/commands/const.go
@@ -11,4 +11,11 @@ const (
 	masterLabelRole = "node-role.kubernetes.io/master"
 
 	gangSchdName = "kube-batchd"
+
+	// labelNodeRolePrefix is a label prefix for node roles
+	// It's copied over to here until it's merged in core: https://github.com/kubernetes/kubernetes/pull/39112
+	labelNodeRolePrefix = "node-role.kubernetes.io/"
+
+	// nodeLabelRole specifies the role of a node
+	nodeLabelRole = "kubernetes.io/role"
 )

--- a/cmd/arena/commands/top_node.go
+++ b/cmd/arena/commands/top_node.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 
 	log "github.com/sirupsen/logrus"
@@ -11,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -128,9 +130,9 @@ func displayTopNodeSummary(nodeInfos []NodeInfo) {
 			}
 		}
 
-		role := "worker"
-		if isMasterNode(nodeInfo.node) {
-			role = "master"
+		role := strings.Join(findNodeRoles(&nodeInfo.node), ",")
+		if len(role) == 0 {
+			role = "<none>"
 		}
 
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", nodeInfo.node.Name,
@@ -174,10 +176,11 @@ func displayTopNodeDetails(nodeInfos []NodeInfo) {
 			address = nodeInfo.node.Status.Addresses[0].Address
 		}
 
-		role := "worker"
-		if isMasterNode(nodeInfo.node) {
-			role = "master"
+		role := strings.Join(findNodeRoles(&nodeInfo.node), ",")
+		if len(role) == 0 {
+			role = "<none>"
 		}
+
 		fmt.Fprintf(w, "\n")
 		fmt.Fprintf(w, "NAME:\t%s\n", nodeInfo.node.Name)
 		fmt.Fprintf(w, "IPADDRESS:\t%s\n", address)
@@ -247,4 +250,24 @@ func isMasterNode(node v1.Node) bool {
 	}
 
 	return false
+}
+
+// findNodeRoles returns the roles of a given node.
+// The roles are determined by looking for:
+// * a node-role.kubernetes.io/<role>="" label
+// * a kubernetes.io/role="<role>" label
+func findNodeRoles(node *v1.Node) []string {
+	roles := sets.NewString()
+	for k, v := range node.Labels {
+		switch {
+		case strings.HasPrefix(k, labelNodeRolePrefix):
+			if role := strings.TrimPrefix(k, labelNodeRolePrefix); len(role) > 0 {
+				roles.Insert(role)
+			}
+
+		case k == nodeLabelRole && v != "":
+			roles.Insert(v)
+		}
+	}
+	return roles.List()
 }


### PR DESCRIPTION
The admin may set role not only worker or master ,maybe some useful information like gpu type ..
This is for user friendly.
```
[xieyd@ec-0d-9a-20-99-00 ~]$ ./arena top node
NAME               IPADDRESS    ROLE            GPU(Total)  GPU(Allocated)
24-8a-07-ff-09-80  10.10.10.32  TitanV          10          10
24-8a-07-ff-09-b0  10.10.10.30  P40             8           8
7c-fe-90-be-a2-a0  10.10.10.10  TitanXP         10          2
7c-fe-90-be-ad-70  10.10.10.12  TitanXP         10          0
7c-fe-90-be-b2-00  10.10.10.16  TitanXP         10          0
7c-fe-90-be-c3-90  10.10.10.15  TitanXP,master  10          10
7c-fe-90-be-c4-00  10.10.10.18  TitanV,master   10          9
ec-0d-9a-d9-86-ea  10.10.10.39  TitanV,master   10          8
ec-0d-9a-d9-87-0a  10.10.10.36  TitanXP         10          3
ec-0d-9a-d9-87-2e  10.10.10.34  TitanXP         10          1
ec-0d-9a-d9-96-c2  10.10.10.35  TitanXP         10          7
ec-0d-9a-d9-9c-72  10.10.10.38  TitanXP         10          3
ec-0d-9a-d9-bf-52  10.10.10.37  TitanXP         10          9
-----------------------------------------------------------------------------------------
Allocated/Total GPUs In Cluster:
70/128 (54%)  

```